### PR TITLE
Fix typo in DataSourceNoCloud.py

### DIFF
--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -119,7 +119,7 @@ class DataSourceNoCloud(sources.DataSource):
                                                pp2d_kwargs)
                     except ValueError:
                         if dev in label_list:
-                            LOG.warning("device %s with label=%s not a"
+                            LOG.warning("device %s with label=%s not a "
                                         "valid seed.", dev, label)
                         continue
 


### PR DESCRIPTION
Actually in log we have
```
 DataSourceNoCloud.py[WARNING]: device /dev/fd0 with label=cidata not avalid seed.
```

This PR just add missing space next to `valid`
```
 DataSourceNoCloud.py[WARNING]: device /dev/fd0 with label=cidata not a valid seed.
```