### PR TITLE
Add missing #cloud-config comment

### DIFF
--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -1,3 +1,4 @@
+#cloud-config
 # Add groups to the system
 # The following example adds the ubuntu group with members 'root' and 'sys'
 # and the empty group cloud-users.


### PR DESCRIPTION
Since this is the first example in the docs, it's rather important to have this line in there. I stumbled across this missing line and wondered why my user config isn't working at all.